### PR TITLE
*corr.via informe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ slide-py: main.tex
 # FORMATO HTML
 ########################################
 
-html: main-sci.html
+html-sci: main-sci.html
 
 html-oct: main-oct.html
 

--- a/cap_integracao/cap_integracao.tex
+++ b/cap_integracao/cap_integracao.tex
@@ -1486,34 +1486,39 @@ printf("%1.7f\n", I5)
 Em \verb+Python+, temos:
 \begin{verbatim}
 def f(x):
-    return np.sqrt(1+x^2)
+    return np.sqrt(1+x**2)
 
 #G-L n=2
-x2 = sqrt(3)/3
-w2 = 1
-I2 = w2[1]*f(x2[1]) + w2[1]*f(-x2[1])
-print("%1.7f\n" % I2)
+x2 = [np.sqrt(3)/3]
+w2 = [1]
+I2 = w2[0]*f(x2[0]) + w2[0]*f(-x2[0])
+print("Para n = 2, I = %1.7f" % I2)
 
 #G-L n=3
-x3 = [0 -sqrt(3/5) sqrt(3/5)]
-w3 = [8/9 5/9 5/9]
-I3 = w3[1]*f(x3[1]) + w3[2]*f(x3[2]) + w3[2]*f(-x3[2]);
-print("%1.7f\n" % I3)
-
+x3 = [0, np.sqrt(3/5)]
+w3 = [8/9, 5/9]
+I3 = (w3[0]*f(x3[0]) +
+      w3[1]*f(x3[1]) + w3[1]*f(-x3[1]))
+print("Para n = 3, I = %1.7f" % I3)
 
 #G-L n=4
-x4 = [sqrt((3-2*sqrt(6/5))/7) sqrt((3+2*sqrt(6/5))/7)]
-w4 = [(18+sqrt(30))/36 (18-sqrt(30))/36]
-I4 = w4(1)*f(x4(1)) + w4(1)*f(-x4(1)) ...
-   + w4(2)*f(x4(2)) + w4(2)*f(-x4(2))
-print("%1.7f\n" % I4)
+x4 = [np.sqrt((3-2*np.sqrt(6/5))/7),
+      np.sqrt((3+2*np.sqrt(6/5))/7)]
+w4 = [(18+np.sqrt(30))/36, (18-np.sqrt(30))/36]
+I4 = (w4[0]*f(x4[0]) + w4[0]*f(-x4[0]) +
+      w4[1]*f(x4[1]) + w4[1]*f(-x4[1]))
+print("Para n = 4, I = %1.7f" % I4)
 
 #G-L n=5
-x5 = [0 1/3*sqrt(5-2*sqrt(10/7)) 1/3*sqrt(5+2*sqrt(10/7))]
-w5 = [128/225 (322+13*sqrt(70))/900 (322-13*sqrt(70))/900]
-I5 = w5(1)*f(x5(1)) + w5(2)*f(x5(2)) + w5(2)*f(-x5(2)) ...
-     + w5(3)*f(x5(3)) + w5(3)*f(-x5(3))
-print("%1.7f\n" % I5)
+x5 = [0,
+      1/3*np.sqrt(5-2*np.sqrt(10/7)),
+      1/3*np.sqrt(5+2*np.sqrt(10/7))]
+w5 = [128/225, (322+13*np.sqrt(70))/900,
+      (322-13*np.sqrt(70))/900]
+I5 = (w5[0]*f(x5[0]) +
+      w5[1]*f(x5[1]) + w5[1]*f(-x5[1]) +
+      w5[2]*f(x5[2]) + w5[2]*f(-x5[2]))
+print("Para n = 5, I = %1.7f" % I5)
 \end{verbatim}
 \fi
 %%%%%%%%%%%%%%%%%%%%
@@ -1583,15 +1588,17 @@ printf("%1.7f\n", I3)
 % python
 %%%%%%%%%%%%%%%%%%%%
 \ifispython
-No \verb+GNU Octave+, podemos computar estas aproximações com o seguinte código:
+Em \verb+Python+, podemos computar estas aproximações com o seguinte código:
 \begin{verbatim}
-def f(u):
-    return sqrt(1+(u+1)^2/4)/2
-
-x3 = [0 -sqrt(3/5) sqrt(3/5)]
-w3 = [8/9 5/9 5/9]
-I3 = f(x3(1))*w3(1) + f(x3(2))*w3(2) + f(-x3(2))*w3(2)
-print("%1.7f\n" % I3)
+def f(u):  
+    return np.sqrt(1+(u+1)**2/4)/2  
+ 
+#G-L n=3
+x3 = [0, np.sqrt(3/5)]  
+w3 = [8/9, 5/9]  
+I3 = (w3[0]*f(x3[0])
+      + w3[1]*f(x3[1]) + w3[1]*f(-x3[1]))
+print("Para n = 3, I = %1.7f" %(I3))
 \end{verbatim}
 \fi
 %%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Correção via informe:
Ref. a URL: https://www.ufrgs.br/numerico/livro-py/in-quadratura_de_gauss-legendre.html

Mensage:
 O algoritmo apresentado em Python, no Exemplo 9.7.1, possui alguns erros (acredito que esteja escrito em GNU Octave), aqui eu apresento uma sugestão para sua correção, além de sugerir uma possível modificação, baseada no exemplo existente, um pouco menos "hardcoded", onde não se necessita inserir o somatório manualmente.
Outra sugestão, agora para o Exemplo 9.7.2, no paragrafo logo acima do código, supostamente em Python, lê-se "No GNU Octave, podemos...", o correto aqui seria "No Python, podemos...", o algoritmo para esse exemplo encontra-se no final do post.
Todos foram testados com sucesso nas versões 2.7 e 3.6 do Python, e por fim, peço perdão pelo post tão longo.


####################
#Correção, Exemplo 9.7.1
####################


def f(x):
    return np.sqrt(1+x**2)

#G-L n=2
x2 = [np.sqrt(3)/3]
w2 = [1]
I2 = w2[0]*f(x2[0]) + w2[0]*f(-x2[0])
print("Para n = 2, I ≅ %1.7f" % I2)

#G-L n=3
x3 = [0, np.sqrt(3/5)]
w3 = [8/9, 5/9]
I3 = (w3[0]*f(x3[0]) +
      w3[1]*f(x3[1]) + w3[1]*f(-x3[1]))
print("Para n = 3, I ≅ %1.7f" % I3)

#G-L n=4
x4 = [np.sqrt((3-2*np.sqrt(6/5))/7),
      np.sqrt((3+2*np.sqrt(6/5))/7)]
w4 = [(18+np.sqrt(30))/36, (18-np.sqrt(30))/36]
I4 = (w4[0]*f(x4[0]) + w4[0]*f(-x4[0]) +
      w4[1]*f(x4[1]) + w4[1]*f(-x4[1]))
print("Para n = 4, I ≅ %1.7f" % I4)

#G-L n=5
x5 = [0,
      1/3*np.sqrt(5-2*np.sqrt(10/7)),
      1/3*np.sqrt(5+2*np.sqrt(10/7))]
w5 = [128/225, (322+13*np.sqrt(70))/900,
      (322-13*np.sqrt(70))/900]
I5 = (w5[0]*f(x5[0]) +
      w5[1]*f(x5[1]) + w5[1]*f(-x5[1]) +
      w5[2]*f(x5[2]) + w5[2]*f(-x5[2]))
print("Para n = 5, I ≅ %1.7f" % I5)



####################
#Sugestão, Exemplo 9.7.1
####################


def raiz(t1,t2=0):
    if (t1!=0):
        return np.sqrt(1+t1**2), np.sqrt(1+t2**2)
    else:
        return np.sqrt(1+t1**2)

def somatorio(t,w):
    I_ns = []
    for i in range(len(w)):
        t_i = t[i]
        w_i = w[i]
        if (t_i==0):
            t_pos = raiz(t_i)
            I_tw = (w_i*t_pos)
        else:
            t_pos, t_neg = raiz(t_i, -t_i)
            I_tw = (w_i*t_pos + w_i*t_neg)
        I_ns.append(I_tw)
    return sum(I_ns)

#Gauss-Legendre n=2
t_n2 = [np.sqrt(3)/3]
w_n2 = [1]
I_n2 = somatorio(t_n2, w_n2)
print("Para n = 2, I ≅ %1.7f" %(I_n2))

#Gauss-Legendre n=3
t_n3 = [0, np.sqrt(3/5)]
w_n3 = [8/9, 5/9]
I_n3 = somatorio(t_n3, w_n3)
print("Para n = 3, I ≅ %1.7f" %(I_n3))

#Gauss-Legendre n=4
t_n4 = [np.sqrt((3-2*np.sqrt(6/5))/7),
        np.sqrt((3+2*np.sqrt(6/5))/7)]
w_n4 = [(18+np.sqrt(30))/36, (18-np.sqrt(30))/36]
I_n4 = somatorio(t_n4, w_n4)
print("Para n = 4, I ≅ %1.7f" %(I_n4))

#Gauss-Legendre n=5
t_n5 = [0,
        1/3*np.sqrt(5-2*np.sqrt(10/7)),
        1/3*np.sqrt(5+2*np.sqrt(10/7))]
w_n5 = [128/225, (322+13*np.sqrt(70))/900,
        (322-13*np.sqrt(70))/900]
I_n5 = somatorio(t_n5, w_n5)
print("Para n = 5, I ≅ %1.7f" %(I_n5))



####################
#Correção, Exemplo 9.7.1
####################


def f(u):  
    return np.sqrt(1+(u+1)**2/4)/2  
 
#G-L n=3
x3 = [0, np.sqrt(3/5)]  
w3 = [8/9, 5/9]  
I3 = (w3[0]*f(x3[0])
      + w3[1]*f(x3[1]) + w3[1]*f(-x3[1]))
print("Para n = 3, I =~ %1.7f" %(I3))