### PR TITLE
Correção de sintaxe Markdown

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,3 @@
-#Licença
+# Licença
 
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite (https://creativecommons.org/licenses/by-sa/3.0/)  ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_ajuste/README.md
+++ b/cap_ajuste/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_ajuste
+# Diretório: cap_ajuste
 
 Este diretório contém o código fonte do capítulo sobre técnicas numéricas para ajuste de curvas.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_ajuste/codes/README.md
+++ b/cap_ajuste/codes/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_ajuste/codes
+# Subdiretório: cap_ajuste/codes
 
 Este subdiretório contém os códigos computacionais trabalhados no capítulo sobre ajuste de curvas.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_ajuste/pics/README.md
+++ b/cap_ajuste/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_ajuste/pics
+# Subdiretório: cap_ajuste/pics
 
 Este subdiretório contém as imagens do capítulo sobre técnicas numéricas de ajuste de curvas.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_ajuste/pics/ex_ajuste_linear/README.md
+++ b/cap_ajuste/pics/ex_ajuste_linear/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_ajuste/pics/ex_ajuste_linear
+# Subdiretório: cap_ajuste/pics/ex_ajuste_linear
 
 Este subdiretório contém o código fonte e a imagem da figura
     ex_ajuste_linear
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_ajuste/pics/ex_ajuste_polinomial/README.md
+++ b/cap_ajuste/pics/ex_ajuste_polinomial/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_ajuste/pics/ex_ajuste_polinomial
+# Subdiretório: cap_ajuste/pics/ex_ajuste_polinomial
 
 Este subdiretório contém o código fonte e a imagem da figura
     ex_ajuste_polinomial
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_ajuste/pics/ex_ajuste_reta2/README.md
+++ b/cap_ajuste/pics/ex_ajuste_reta2/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_ajuste/pics/ex_ajuste_reta2
+# Subdiretório: cap_ajuste/pics/ex_ajuste_reta2
 
 Este subdiretório contém o código fonte e a imagem da figura
     ex_ajuste_reta2
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_ajuste/pics/ex_intro_ajuste/README.md
+++ b/cap_ajuste/pics/ex_intro_ajuste/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_interp/pics/ex_intro_ajuste
+# Subdiretório: cap_interp/pics/ex_intro_ajuste
 
 Este subdiretório contém o código fonte e a imagem da figura
     ex_intro_ajuste
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_aritmetica/README.md
+++ b/cap_aritmetica/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_aritmetica
+# Diretório: cap_aritmetica
 
 Este diretório contém o código fonte do capítulo sobre aritmética de máquina.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_aritmetica/pics/README.md
+++ b/cap_aritmetica/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_artimetica/pics
+# Subdiretório: cap_artimetica/pics
 
 Este é o subdiretório de imagens do capítulo sobre aritmética de máquina.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_derivacao/README.md
+++ b/cap_derivacao/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_derivacao
+# Diretório: cap_derivacao
 
 Este diretório contém o código fonte do capítulo sobre técnicas numéricas para derivação de funções reais.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_derivacao/codes/README.md
+++ b/cap_derivacao/codes/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_derivacao/codes
+# Subdiretório: cap_derivacao/codes
 
 Este subdiretório contém os códigos computacionais trabalhados no capítulo sobre técnicas numéricas de derivação de funções reais.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_derivacao/pics/README.md
+++ b/cap_derivacao/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_derivacao/pics
+# Subdiretório: cap_derivacao/pics
 
 Este subdiretório contém as imagens do capítulo sobre técnicas numéricas de derivação de funções reais.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_derivacao/pics/ex_derivacao/README.md
+++ b/cap_derivacao/pics/ex_derivacao/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_derivacao/pics/ex_derivacao
+# Subdiretório: cap_derivacao/pics/ex_derivacao
 
 Este subdiretório contém o código fonte e a imagem da figura
     ex_derivacao
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_derivacao/pics/ex_derivacao2/README.md
+++ b/cap_derivacao/pics/ex_derivacao2/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_derivacao/pics/ex_derivacao2
+# Subdiretório: cap_derivacao/pics/ex_derivacao2
 
 Este subdiretório contém o código fonte e a imagem da figura
     ex_derivacao2
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/README.md
+++ b/cap_equacao1d/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_equacao1d
+# Diretório: cap_equacao1d
 
 Este diretório contém o código fonte do capítulo sobre técnicas numéricas para a solução de equações de uma variável.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/codes/README.md
+++ b/cap_equacao1d/codes/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_equacao1d/codes
+# Subdiretório: cap_equacao1d/codes
 
 Este subdiretório contém os códigos computacionais trabalhados no capítulo sobre técnicas numéricas para a solução de equações de uma variável.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/codes/octave/README.md
+++ b/cap_equacao1d/codes/octave/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_equacao1d/codes/octave
+# Subdiretório: cap_equacao1d/codes/octave
 
 Este subdiretório contém códigos em `GNU Octave` trabalhados no capítulo sobre técnicas numéricas para a solução de equações de uma variável.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/codes/octave/metodo_da_bissecao/README.md
+++ b/cap_equacao1d/codes/octave/metodo_da_bissecao/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_equacao1d/codes/octave/metodo_da_bissecao
+# Subdiretório: cap_equacao1d/codes/octave/metodo_da_bissecao
 
 Este subdiretório contém o código em `GNU Octave` do método da bisseção.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/codes/python/README.md
+++ b/cap_equacao1d/codes/python/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_equacao1d/codes/python
+# Subdiretório: cap_equacao1d/codes/python
 
 Este subdiretório contém códigos em Python trabalhados no capítulo sobre técnicas numéricas para a solução de equações de uma variável.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/codes/python/metodo_da_bissecao/README.md
+++ b/cap_equacao1d/codes/python/metodo_da_bissecao/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_equacao1d/codes/python/metodo_da_bissecao
+# Subdiretório: cap_equacao1d/codes/python/metodo_da_bissecao
 
 Este subdiretório contém o código Python do método da bisseção.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/codes/scilab/README.md
+++ b/cap_equacao1d/codes/scilab/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_equacao1d/codes/scilab
+# Subdiretório: cap_equacao1d/codes/scilab
 
 Este subdiretório contém códigos em Scilab trabalhados no capítulo sobre técnicas numéricas para a solução de equações de uma variável.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/codes/scilab/metodo_da_bissecao/README.md
+++ b/cap_equacao1d/codes/scilab/metodo_da_bissecao/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_equacao1d/codes/scilab/metodo_da_bissecao
+# Subdiretório: cap_equacao1d/codes/scilab/metodo_da_bissecao
 
 Este subdiretório contém o código Scilab do método da bisseção.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/pics/README.md
+++ b/cap_equacao1d/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_equacao1d/pics
+# Subdiretório: cap_equacao1d/pics
 
 Este subdiretório contém as imagens do capítulo sobre técnicas numéricas para a solução de equações de uma variável.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/pics/ex_metodo_da_bissecao/README.md
+++ b/cap_equacao1d/pics/ex_metodo_da_bissecao/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_equacao1d/pics/ex_metodo_da_bissecao
+# Subdiretório: cap_equacao1d/pics/ex_metodo_da_bissecao
 
 Este subdiretório contém o código fonte e o arquivo de imagem da figura:
 ex_metodo_da_bissecao
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/pics/ex_ponto_fixo_3/README.md
+++ b/cap_equacao1d/pics/ex_ponto_fixo_3/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_equacao1d/pics/ex_ponto_fixo_3
+# Subdiretório: cap_equacao1d/pics/ex_ponto_fixo_3
 
 Este subdiretório contém o código fonte e o arquivo de imagem da figura:
 ex_ponto_fixo_3
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/pics/metodo_da_bissecao/README.md
+++ b/cap_equacao1d/pics/metodo_da_bissecao/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_equacao1d/pics/metodo_da_bissecao
+# Subdiretório: cap_equacao1d/pics/metodo_da_bissecao
 
 Este subdiretório contém o código fonte e o arquivo de imagem da figura:
 metodo_da_bissecao
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/pics/metodo_de_Newton/README.md
+++ b/cap_equacao1d/pics/metodo_de_Newton/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_equacao1d/pics/metodo_de_Newton
+# Subdiretório: cap_equacao1d/pics/metodo_de_Newton
 
 Este subdiretório contém o código fonte e o arquivo de imagem da figura:
 metodo_de_Newton.eps
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/pics/ponto_fixo_estavel/README.md
+++ b/cap_equacao1d/pics/ponto_fixo_estavel/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_equacao1d/pics/ponto_fixo_estavel
+# Subdiretório: cap_equacao1d/pics/ponto_fixo_estavel
 
 Este subdiretório contém o código fonte e o arquivo de imagem da figura:
 ponto_fixo_estavel
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/pics/ponto_fixo_instavel/README.md
+++ b/cap_equacao1d/pics/ponto_fixo_instavel/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_equacao1d/pics/ponto_fixo_instavel
+# Subdiretório: cap_equacao1d/pics/ponto_fixo_instavel
 
 Este subdiretório contém o código fonte e o arquivo de imagem da figura:
 ponto_fixo_instavel
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_equacao1d/pics/teorema_de_Bolzano/README.md
+++ b/cap_equacao1d/pics/teorema_de_Bolzano/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_equacao1d/pics/teorema_de_Bolzano
+# Subdiretório: cap_equacao1d/pics/teorema_de_Bolzano
 
 Este subdiretório contém o código fonte e o arquivo de imagem da figura:
 teorema_de_Bolzano.eps
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_integracao/README.md
+++ b/cap_integracao/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_derint
+# Diretório: cap_derint
 
 Este diretório contém o código fonte do capítulo sobre técnicas numéricas para derivação e integração de funções.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_integracao/codes/README.md
+++ b/cap_integracao/codes/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_integracao/codes
+# Subdiretório: cap_integracao/codes
 
 Este subdiretório contém os códigos computacionais trabalhados no capítulo sobre técnicas numéricas de integração de funções reais.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_integracao/codes/gauss_legendre/README.md
+++ b/cap_integracao/codes/gauss_legendre/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_integracao/codes/gauss_legendre
+# Subdiretório: cap_integracao/codes/gauss_legendre
 
 Este subdiretório contém os códigos computacionais de quadraturas de Gauss-Legendre.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_integracao/codes/scilab/README.md
+++ b/cap_integracao/codes/scilab/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_integracao/codes/scilab
+# Subdiretório: cap_integracao/codes/scilab
 
 Este subdiretório contém os códigos computacionais em `Scilab`trabalhados no capítulo sobre técnicas numéricas de integração de funções reais.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_integracao/codes/simp_comp/README.md
+++ b/cap_integracao/codes/simp_comp/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_integracao/codes/simp_comp
+# Subdiretório: cap_integracao/codes/simp_comp
 
 Este subdiretório contém os códigos computacionais do método composto de Simpson.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_integracao/codes/trap_comp/README.md
+++ b/cap_integracao/codes/trap_comp/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_integracao/codes/trap_comp
+# Subdiretório: cap_integracao/codes/trap_comp
 
 Este subdiretório contém os códigos computacionais do método composto do trapézio.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_integracao/pics/README.md
+++ b/cap_integracao/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_integracao/pics
+# Subdiretório: cap_integracao/pics
 
 Este subdiretório contém as imagens do capítulo sobre técnicas numéricas de integração de funções reais.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_integracao/pics/int_1/README.md
+++ b/cap_integracao/pics/int_1/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_integracao/pics/int_1
+# Subdiretório: cap_integracao/pics/int_1
 
 Contém a figura int_1 e seu código fonte.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_integracao/pics/int_2/README.md
+++ b/cap_integracao/pics/int_2/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_integracao/pics/int_2
+# Subdiretório: cap_integracao/pics/int_2
 
 Contém a figura int_2 e seu código fonte.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_interp/README.md
+++ b/cap_interp/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_interp
+# Diretório: cap_interp
 
 Este diretório contém o código fonte do capítulo sobre técnicas numéricas para interpolação e aproximação de funções.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_interp/codes/README.md
+++ b/cap_interp/codes/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_interp/codes
+# Subdiretório: cap_interp/codes
 
 Este subdiretório contém os códigos computacionais trabalhados no capítulo sobre técnicas numéricas de interpolação, aproximação de funções e ajuste de curvas.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_interp/codes/interpolacao_linear_segmentada/README.md
+++ b/cap_interp/codes/interpolacao_linear_segmentada/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_interp/codes/interpolacao_linear_segmentada
+# Subdiretório: cap_interp/codes/interpolacao_linear_segmentada
 
 Este subdiretório contém os códigos computacionais de interpolação linear segmentada.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_interp/codes/splines/README.md
+++ b/cap_interp/codes/splines/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_interp/codes/splines
+# Subdiretório: cap_interp/codes/splines
 
 Este subdiretório contém os códigos computacionais de splines cúbicos.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_interp/pics/README.md
+++ b/cap_interp/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_aproxfun/pics
+# Subdiretório: cap_aproxfun/pics
 
 Este subdiretório contém as imagens do capítulo sobre técnicas numéricas de interpolação, aproximação de funções e ajuste de curvas.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_interp/pics/ex_interpolacao_polinomial/README.md
+++ b/cap_interp/pics/ex_interpolacao_polinomial/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_interp/pics/ex_interpolacao_polinomial_
+# Subdiretório: cap_interp/pics/ex_interpolacao_polinomial_
 
 Este subdiretório contém o código fonte e a imagem da figura
     ex_interpolacao_polinomial
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_interp/pics/ex_intro_interpolacao/README.md
+++ b/cap_interp/pics/ex_intro_interpolacao/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_aproxfun/pics/ex_intro_interpolacao
+# Subdiretório: cap_aproxfun/pics/ex_intro_interpolacao
 
 Este subdiretório contém o código fonte e a imagem da figura
     ex_intro_interpolacao
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_intro/README.md
+++ b/cap_intro/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_intro
+# Diretório: cap_intro
 
 Este diretório contém o código fonte do capítulo de introdução do livro.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/README.md
+++ b/cap_linsis/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_linsis
+# Diretório: cap_linsis
 
 Este diretório contém o código fonte do capítulo sobre técnicas numéricas para a solução de sistemas de equações lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/README.md
+++ b/cap_linsis/codes/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes
+# Subdiretório: cap_linsis/codes
 
 Este subdiretório contém os códigos computacionais trabalhados no capítulo sobre técnicas numéricas para a solução de sistemas de equações lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/octave/README.md
+++ b/cap_linsis/codes/octave/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/octave
+# Subdiretório: cap_linsis/codes/octave
 
 Este subdiretório contém os códigos em `GNU Octave` trabalhados no capítulo sobre técnicas numéricas para a solução de sistemas de equações lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/octave/fatoraLU/README.md
+++ b/cap_linsis/codes/octave/fatoraLU/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/octave/fatoraLU
+# Subdiretório: cap_linsis/codes/octave/fatoraLU
 
 Este subdiretório contém o código em `GNU Octave` do método de fatoração LU.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/octave/metodo_da_matriz_tridiagonal/README.md
+++ b/cap_linsis/codes/octave/metodo_da_matriz_tridiagonal/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/octave/metodo_da_matriz_tridiagonal
+# Subdiretório: cap_linsis/codes/octave/metodo_da_matriz_tridiagonal
 
 Este subdiretório contém o código em `GNU Octave` do método matriz tridiagonal.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/octave/metodo_de_gauss-seidel/README.md
+++ b/cap_linsis/codes/octave/metodo_de_gauss-seidel/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/octave/metodo_de_gauss-seidel
+# Subdiretório: cap_linsis/codes/octave/metodo_de_gauss-seidel
 
 Este subdiretório contém o código em `GNU Octave` do método de Gauss-Seidel para sistemas lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/octave/metodo_de_jacobi/README.md
+++ b/cap_linsis/codes/octave/metodo_de_jacobi/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/octave/metodo_de_jacobi
+# Subdiretório: cap_linsis/codes/octave/metodo_de_jacobi
 
 Este subdiretório contém o código `GNU Octave` do método de Jacobi para sistemas lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/python/README.md
+++ b/cap_linsis/codes/python/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/python
+# Subdiretório: cap_linsis/codes/python
 
 Este subdiretório contém os códigos Python trabalhados no capítulo sobre técnicas numéricas para a solução de sistemas de equações lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/python/fatoraLU/README.md
+++ b/cap_linsis/codes/python/fatoraLU/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/python/fatoraLU
+# Subdiretório: cap_linsis/codes/python/fatoraLU
 
 Este subdiretório contém o código em `Python` do método de fatoração LU.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/python/metodo_da_matriz_tridiagonal/README.md
+++ b/cap_linsis/codes/python/metodo_da_matriz_tridiagonal/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/python/metodo_da_matriz_tridiagonal
+# Subdiretório: cap_linsis/codes/python/metodo_da_matriz_tridiagonal
 
 Este subdiretório contém o código Python do método da matriz tridiagonal para sistemas lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/python/metodo_de_gauss-seidel/README.md
+++ b/cap_linsis/codes/python/metodo_de_gauss-seidel/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/python/metodo_de_gauss-seidel
+# Subdiretório: cap_linsis/codes/python/metodo_de_gauss-seidel
 
 Este subdiretório contém o código Python do método de Gauss-Seidel para sistemas lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/python/metodo_de_jacobi/README.md
+++ b/cap_linsis/codes/python/metodo_de_jacobi/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/python/metodo_de_jacobi
+# Subdiretório: cap_linsis/codes/python/metodo_de_jacobi
 
 Este subdiretório contém o código Python do método de Jacobi para sistemas lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/scilab/README.md
+++ b/cap_linsis/codes/scilab/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/scilab
+# Subdiretório: cap_linsis/codes/scilab
 
 Este subdiretório contém os códigos em `Scilab` trabalhados no capítulo sobre técnicas numéricas para a solução de sistemas de equações lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/scilab/fatoraLU/README.md
+++ b/cap_linsis/codes/scilab/fatoraLU/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/scilab/fatoraLU
+# Subdiretório: cap_linsis/codes/scilab/fatoraLU
 
 Este subdiretório contém o código em `Scilab` do método de fatoração LU.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/scilab/metodo_da_matriz_tridiagonal/README.md
+++ b/cap_linsis/codes/scilab/metodo_da_matriz_tridiagonal/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/scilab/metodo_da_matriz_tridiagonal
+# Subdiretório: cap_linsis/codes/scilab/metodo_da_matriz_tridiagonal
 
 Este subdiretório contém o código Scilab do método da matriz tridiagonal para sistemas lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/scilab/metodo_de_gauss-seidel/README.md
+++ b/cap_linsis/codes/scilab/metodo_de_gauss-seidel/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/scilab/metodo_de_gauss-seidel
+# Subdiretório: cap_linsis/codes/scilab/metodo_de_gauss-seidel
 
 Este subdiretório contém o código Scilab do método de Gauss-Seidel para sistemas lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/codes/scilab/metodo_de_jacobi/README.md
+++ b/cap_linsis/codes/scilab/metodo_de_jacobi/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/codes/scilab/metodo_de_jacobi
+# Subdiretório: cap_linsis/codes/scilab/metodo_de_jacobi
 
 Este subdiretório contém o código Scilab do método de Jacobi para sistemas lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_linsis/pics/README.md
+++ b/cap_linsis/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_linsis/pics
+# Subdiretório: cap_linsis/pics
 
 Este subdiretório contém as imagens do capítulo sobre técnicas numéricas para a solução de sistemas de equações lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/README.md
+++ b/cap_nlinsis/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_nlinsis
+# Diretório: cap_nlinsis
 
 Este diretório contém o código fonte do capítulo sobre técnicas numéricas para a solução de sistemas de equações não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/codes/README.md
+++ b/cap_nlinsis/codes/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_nlinsis/codes
+# Subdiretório: cap_nlinsis/codes
 
 Este subdiretório contém os códigos computacionais trabalhados no capítulo sobre técnicas numéricas para a solução de sistemas de equações não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/codes/metodo_de_newton/README.md
+++ b/cap_nlinsis/codes/metodo_de_newton/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_nlinsis/codes/metodo_de_newton
+# Subdiretório: cap_nlinsis/codes/metodo_de_newton
 
 Este subdiretório contém os códigos computacionais do método de Newton para sistemas não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/codes/octave/README.md
+++ b/cap_nlinsis/codes/octave/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_nlinsis/codes/octave
+# Subdiretório: cap_nlinsis/codes/octave
 
 Este subdiretório contém os códigos `GNU Octave` trabalhados no capítulo sobre técnicas numéricas para a solução de sistemas de equações não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/codes/octave/metodo_de_newton/README.md
+++ b/cap_nlinsis/codes/octave/metodo_de_newton/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_nlinsis/codes/octave/metodo_de_newton
+# Subdiretório: cap_nlinsis/codes/octave/metodo_de_newton
 
 Este subdiretório contém o código `GNU Octave` do método de Newton para sistemas não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/codes/python/README.md
+++ b/cap_nlinsis/codes/python/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_nlinsis/codes/python
+# Subdiretório: cap_nlinsis/codes/python
 
 Este subdiretório contém os códigos Python trabalhados no capítulo sobre técnicas numéricas para a solução de sistemas de equações não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/codes/python/metodo_de_newton/README.md
+++ b/cap_nlinsis/codes/python/metodo_de_newton/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_nlinsis/codes/python/metodo_de_newton
+# Subdiretório: cap_nlinsis/codes/python/metodo_de_newton
 
 Este subdiretório contém o código Python do método de Newton para sistemas não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/codes/scilab/README.md
+++ b/cap_nlinsis/codes/scilab/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_nlinsis/codes/scilab
+# Subdiretório: cap_nlinsis/codes/scilab
 
 Este subdiretório contém os códigos Scilab trabalhados no capítulo sobre técnicas numéricas para a solução de sistemas de equações não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/codes/scilab/metodo_de_newton/README.md
+++ b/cap_nlinsis/codes/scilab/metodo_de_newton/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_nlinsis/codes/scilab/metodo_de_newton
+# Subdiretório: cap_nlinsis/codes/scilab/metodo_de_newton
 
 Este subdiretório contém o código Scilab do método de Newton para sistemas não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_nlinsis/pics/README.md
+++ b/cap_nlinsis/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_nlinsis/pics
+# Subdiretório: cap_nlinsis/pics
 
 Este subdiretório contém as imagens do capítulo sobre técnicas numéricas para solução de sistemas de equações não lineares.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_octave/README.md
+++ b/cap_octave/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_octave
+# Diretório: cap_octave
 
 Este diretório contém o código fonte do capítulo de introdução ao Octave.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_pvc/README.md
+++ b/cap_pvc/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_pvc
+# Diretório: cap_pvc
 
 Este diretório contém o código fonte do capítulo sobre técnicas numéricas para problemas de valores de controno.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_pvc/codes/README.md
+++ b/cap_pvc/codes/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_pvc/codes
+# Subdiretório: cap_pvc/codes
 
 Este subdiretório contém os códigos computacionais trabalhados no capítulo sobre técnicas numéricas para problemas de valores de contorno.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_pvc/pics/README.md
+++ b/cap_pvc/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_pvc/pics
+# Subdiretório: cap_pvc/pics
 
 Este subdiretório contém as imagens do capítulo sobre técnicas numéricas para problemas de valores de contorno.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_pvc/pics/ex_pvc2/README.md
+++ b/cap_pvc/pics/ex_pvc2/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_pvc/pics/ex_pvc2
+# Subdiretório: cap_pvc/pics/ex_pvc2
 
 Este subdiretório contém o código e a imagem
 ex_pvc2
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_pvc/pics/exeresol_pvc_linear/README.md
+++ b/cap_pvc/pics/exeresol_pvc_linear/README.md
@@ -1,7 +1,7 @@
-#Subdiretório: cap_pvc/pics/exeresol_pvc_linear
+# Subdiretório: cap_pvc/pics/exeresol_pvc_linear
 
 Este subdiretório contém o código e a imagem
 exeresol_pvc_linear
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_pvi/README.md
+++ b/cap_pvi/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_pvi
+# Diretório: cap_pvi
 
 Este diretório contém o código fonte do capítulo sobre técnicas numéricas para problemas de valor inicial.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_pvi/codes/README.md
+++ b/cap_pvi/codes/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_pvi/codes
+# Subdiretório: cap_pvi/codes
 
 Este subdiretório contém os códigos computacionais trabalhados no capítulo sobre técnicas numéricas para problemas de valor inicial.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_pvi/pics/README.md
+++ b/cap_pvi/pics/README.md
@@ -1,6 +1,6 @@
-#Subdiretório: cap_pvi/pics
+# Subdiretório: cap_pvi/pics
 
 Este subdiretório contém as imagens do capítulo sobre técnicas numéricas para problemas de valor inicial.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_python/README.md
+++ b/cap_python/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_python
+# Diretório: cap_python
 
 Este diretório contém o código fonte do capítulo de introdução à linguagem Python.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/cap_scilab/README.md
+++ b/cap_scilab/README.md
@@ -1,6 +1,6 @@
-#Diretório: cap_scilab
+# Diretório: cap_scilab
 
 Este diretório contém o código fonte do capítulo de introdução ao Scilab.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.

--- a/rosto/README.md
+++ b/rosto/README.md
@@ -1,6 +1,6 @@
-#Diretório: rosto
+# Diretório: rosto
 
 Este diretório contém o código fonte da imagem de capa do livro.
 
-##Licença
+## Licença
 Este trabalho está licenciado sob a Licença Creative Commons Atribuição-CompartilhaIgual 3.0 Não Adaptada. Para ver uma cópia desta licença, visite https://creativecommons.org/licenses/by-sa/3.0/ ou envie uma carta para Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.


### PR DESCRIPTION
A [especificação](http://spec.commonmark.org/0.17/#atx-headers) requer um espaço depois de `#`.