### PR TITLE
Equação 9.30 do exemplo 9.2.1 corrigida

### DIFF
--- a/cap_integracao/cap_integracao.tex
+++ b/cap_integracao/cap_integracao.tex
@@ -336,7 +336,7 @@ onde $h=b-a$.
   Usando a regra do ponto médio, temos
   \begin{equation}
     \begin{split}
-    \int_{0,1}^{0,3} e^{-x}\sen(x)\,dx &\approx f(\frac{a+b}{2}) \\
+    \int_{0,1}^{0,3} e^{-x}\sen(x)\,dx &\approx (a-b) f(\frac{a+b}{2}) \\
     &= 0,2e^{-0,2}\sen(0,2) = 3,25313\times 10^{-2}.
     \end{split}
   \end{equation}


### PR DESCRIPTION
A equação da regra do ponto médio não tinha (a-b) na multiplicação.