### PR TITLE
Correção em Runge kutta explícito

### DIFF
--- a/cap_pvi/cap_pvi.tex
+++ b/cap_pvi/cap_pvi.tex
@@ -1290,7 +1290,7 @@ onde $b_j$ são os pesos da quadratura numérica que aproxima a integral. Assim 
     \tilde{u}_3 &= u_n  + h \left[a_{31}k_1 + a_{32}k_2\right] \\
     \tilde{u}_4 &= u_n  + h \left[a_{41}k_1 + a_{42}k_2 + a_{43}k_3\right] \\
     &\vdots \\
-    \tilde{u}_\nu &= u_n  + h \left[a_{\nu 1}k_1 + a_{\nu 2}k_2 + \cdots +a_{\nu \nu}k_\nu\right] \\
+    \tilde{u}_\nu &= u_n  + h \left[a_{\nu 1}k_1 + a_{\nu 2}k_2 + \cdots +a_{\nu (\nu-1)}k_{\nu-1}\right] \\
     u^{(n+1)}&= u_n + h [ b_1k_1+b_2k_2+\cdots + b_\nu k_\nu],
   \end{split}
 \end{equation}
@@ -1304,7 +1304,7 @@ onde $k_j=f\left(\tau_j,\tilde{u}_{j}\right)$, $A:=\left(a_{ij}\right)$ é a mat
 \begin{tabular}{c|ccc}
   $c_1$  & $0$      & $0$      & $0$ \\
   $c_2$  & $a_{21}$ & $0$      & $0$ \\
-  $c_3$ & $a_{31}$ & $a_{22}$ & $0$\\  \hline
+  $c_3$ & $a_{31}$ & $a_{32}$ & $0$\\  \hline
         & $b_1$     & $b_2$     & $b_3$.
 \end{tabular}
 ~~~$=$~~~


### PR DESCRIPTION
1. Até \nu-1, para manter o método explícito
2. Ajuste no índice do elemento na matriz a32