### PR TITLE
Método de newton pequeno erro de digitação

### DIFF
--- a/cap_equacao1d/cap_equacao1d.tex
+++ b/cap_equacao1d/cap_equacao1d.tex
@@ -1359,7 +1359,7 @@ se $f'(x^*)\neq 0$.
 
 A discussão acima nos motiva a introduzir o método de Newton, cujas iterações são dada por:
 \begin{equation}
-  x^{(n+1)} = x^{(n)} - \frac{f\left(x^{(n)}\right)}{f'\left(x^{n}\right)}, \quad n\geq 1,
+  x^{(n+1)} = x^{(n)} - \frac{f\left(x^{(n)}\right)}{f'\left(x^{(n)}\right)}, \quad n\geq 1,
 \end{equation}
 sendo $x^{(1)}$ uma aproximação inicial dada.
 


### PR DESCRIPTION
Troquei x^n por x^{(n)} pois pode levar a interpretações erradas de que o x ali é elevado a n