### PR TITLE
Erro de dígito na equação (4.26)

### DIFF
--- a/cap_linsis/cap_linsis.tex
+++ b/cap_linsis/cap_linsis.tex
@@ -589,7 +589,7 @@ Agora, quando usamos a eliminação gaussiana com pivotamento parcial, fazemos u
 \end{equation}
 
 Continuando o procedimento, temos:
-\begin{equation} y=\frac{4-4\varepsilon}{2-\varepsilon^2} \end{equation} e
+\begin{equation} y=\frac{4-3\varepsilon}{2-\varepsilon^2} \end{equation} e
 \begin{equation} x=3-\varepsilon y \end{equation}
 
 Observe que tais expressões são analiticamente idênticas às anteriores, no entanto, são mais estáveis numericamente. Quando $\varepsilon$ converge a zero, $y$ converge a $2$, como no caso anterior. No entanto, mesmo que $y=2$, a segunda expressão produz $x=3-\varepsilon y$, isto é, a aproximação $x\approx 3$ não depende mais de obter $2-y$ com precisão.


### PR DESCRIPTION
A equação 4.26 estava com um de seus dígitos errados.


