### PR TITLE
Correção dos sinais em (9.77) e (9.78) e adiciona fator 2 em (9.76)

### DIFF
--- a/cap_integracao/cap_integracao.tex
+++ b/cap_integracao/cap_integracao.tex
@@ -566,7 +566,7 @@ e
 \end{equation}
 temos
 \begin{equation}
-\int_a^bf(x)\;dx=hf(x_2)+\frac{h^3}{3}f''(x_2)+\frac{h^5f^{(4)}(\eta)}{60}.
+\int_a^bf(x)\;dx=2hf(x_2)+\frac{h^3}{3}f''(x_2)+\frac{h^5f^{(4)}(\eta)}{60}.
 \end{equation}
 Usando a fórmula de diferenças finitas centrais para a derivada segunda:
 \begin{equation}

--- a/cap_integracao/cap_integracao.tex
+++ b/cap_integracao/cap_integracao.tex
@@ -570,11 +570,11 @@ temos
 \end{equation}
 Usando a fórmula de diferenças finitas centrais para a derivada segunda:
 \begin{equation}
-f''(x_2)=\frac{f(x_1)-2f(x_2)+f(x_3)}{h^2}+\frac{h^2}{12}f^{(4)}(\eta_2),
+f''(x_2)=\frac{f(x_1)-2f(x_2)+f(x_3)}{h^2}-\frac{h^2}{12}f^{(4)}(\eta_2),
 \end{equation}
 $x_1\leq \eta_2\leq x_3$, temos
 \begin{eqnarray}
-\int_a^bf(x)\;dx&=&2hf(x_2)+\frac{h^3}{3}\left(\frac{f(x_1)-2f(x_2)+f(x_3)}{h^2}+\frac{h^2}{12}f^{(4)}(\eta_2)\right)\\
+\int_a^bf(x)\;dx&=&2hf(x_2)+\frac{h^3}{3}\left(\frac{f(x_1)-2f(x_2)+f(x_3)}{h^2}-\frac{h^2}{12}f^{(4)}(\eta_2)\right)\\
 &+&\frac{h^5f^{(4)}(\eta)}{60}\\
 &=&\frac{h}{3}\left(f(x_1)+4f(x_2)+f(x_3)\right)-\frac{h^5}{12}\left(\frac{1}{3}f^{(4)}(\eta_2)-\frac{1}{5}f^{(4)}(\eta)\right).
 \end{eqnarray}


### PR DESCRIPTION
Acredito haver um erro no sinal dos últimos termos em 9.77 e 9.78 no capítulo de integração numérica, encontrei por indicação de um professor(Loïc Cerf).

Aviso sobre esses erros:
    - https://www.ufrgs.br/reamat/forum.html?place=msg%2Freamat%2FrnpCrJRw1Pk%2FIWHXoT21AwAJ

Também realizei consulta em:
    - https://www.ufsj.edu.br/portal2-repositorio/File/nepomuceno/mn/09MN_Derivacao.pdf