### PR TITLE
Correção cap_derivacao.tex em relação ao crescimento do erro no exemplo

### DIFF
--- a/cap_derivacao/cap_derivacao.tex
+++ b/cap_derivacao/cap_derivacao.tex
@@ -105,7 +105,7 @@ E, similarmente, para outros valores de $x_0$ e $h$.
   \label{fig:ex_derivacao}
 \end{figure}
 
-Exploremos o Exemplo~\ref{ex:dp} um pouco mais. Observamos que, para valores moderados de $h$, o erro $|f'(1)-D_{+,h}f(1)|$ diminui linearmente com $h$ (veja Figura~\ref{fig:ex_derivacao}). Isto é consequência da ordem de truncamento da fórmula de diferenças finitas aplicada (que é de ordem 1). Porém, para valores muito pequenos de $h < 10^{-8}$, o erro passa a aumentar quando diminuímos $h$. Isto é devido ao efeito de cancelamento catastrófico.
+Exploremos o Exemplo~\ref{ex:dp} um pouco mais. Observamos que, para valores moderados de $h$, o erro $|f'(1)-D_{+,h}f(1)|$ diminui exponencialmente com $h$ (veja Figura~\ref{fig:ex_derivacao}). Isto é consequência da ordem de truncamento da fórmula de diferenças finitas aplicada (que é de ordem 1). Porém, para valores muito pequenos de $h < 10^{-8}$, o erro passa a aumentar quando diminuímos $h$. Isto é devido ao efeito de cancelamento catastrófico.
 
 \subsection{Diferenças finitas via série de Taylor}
 


### PR DESCRIPTION
Visto que o gráfico está linearizado, o erro está caindo exponencialmente ao invés de linearmente.