### PR TITLE
Correção de referência para a figura do ex 2

### DIFF
--- a/cap_derivacao/cap_derivacao.tex
+++ b/cap_derivacao/cap_derivacao.tex
@@ -198,7 +198,7 @@ Calcule a derivada numérica da função $f(x)=e^{\frac{1}{2}x}$ no ponto $x=2$ 
 
 
 \begin{obs}
-  O experimento numérico realizado no Exemplo~\ref{ex:derivacao2}, nos mostra que o erro absoluto na derivação numérica não é da ordem do erro de truncamento. Entretanto, este erro tende a variar com $h$ na mesma ordem do erro de truncamento. A Figura~\ref{ex:derivacao2} apresenta o erro absoluto das derivadas numéricas computadas para o Exemplo~\ref{ex:derivacao2}. Note que, devido ao efeito de cancelamento catastrófico, o erro absoluto deixa de variar na ordem do erro de truncamento para valores muito pequenos de $h$.
+  O experimento numérico realizado no Exemplo~\ref{ex:derivacao2}, nos mostra que o erro absoluto na derivação numérica não é da ordem do erro de truncamento. Entretanto, este erro tende a variar com $h$ na mesma ordem do erro de truncamento. A Figura~\ref{fig:ex_derivacao2} apresenta o erro absoluto das derivadas numéricas computadas para o Exemplo~\ref{ex:derivacao2}. Note que, devido ao efeito de cancelamento catastrófico, o erro absoluto deixa de variar na ordem do erro de truncamento para valores muito pequenos de $h$.
 \end{obs}
 
 % \subsection{Erros de truncamento}\index{erros!truncamento}


### PR DESCRIPTION
Estava utilizando a label do exemplo no lugar do label da figura.