### PR TITLE
Update cap_aritmetica.tex

### DIFF
--- a/cap_aritmetica/cap_aritmetica.tex
+++ b/cap_aritmetica/cap_aritmetica.tex
@@ -2048,7 +2048,7 @@ Este erro é bem pequeno para a maioria das aplicações! Assumindo que $x$ e $y
 
 Mesmo que fizéssemos, por exemplo, $1000$ operações elementares sucessivas em ponto flutuante, teríamos, no pior dos casos, acumulado todos esses erros e perdido $3$ casas decimais ($1000\times 10^{-15} \approx 10^{-12})$.
 
-Entretanto, quando subtraímos números muito próximos, o erro pode se propagar de forma catastrófico.
+Entretanto, quando subtraímos números muito próximos, o erro pode se propagar de forma catastrófica.
 
 \section{Cancelamento catastrófico}\index{cancelamento catastrófico}
 

--- a/cap_aritmetica/cap_aritmetica.tex
+++ b/cap_aritmetica/cap_aritmetica.tex
@@ -443,7 +443,7 @@ ans = BEBA
 %%%%%%%%%%%%%%%%%%%%
 
 \begin{obs}
-  Uma maneira de converter um número dado em uma base $b_1$ para uma base $b_2$ é fazer em duas partes: primeiro converter o número dado na base $b_2$ para base decimal e depois converter para a base $b_1$.
+  Uma maneira de converter um número dado em uma base $b_1$ para uma base $b_2$ é fazer em duas partes: primeiro converter o número dado na base $b_1$ para base decimal e depois converter para a base $b_2$.
 \end{obs}
 
 \subsection*{Exercícios resolvidos}

--- a/cap_aritmetica/cap_aritmetica.tex
+++ b/cap_aritmetica/cap_aritmetica.tex
@@ -45,7 +45,7 @@ representa o número positivo
 \begin{equation}
   d_n\cdot b^n + d_{n-1}\cdot b^{n-1} + \cdots + d_0\cdot b^0 + d_{-1}\cdot b^{-1}+d_{-2}\cdot b^{-2} + \cdots
 \end{equation}
-Para representar números negativos usamos o símbolo $-$ a esquerda do numeral\footnote{O uso do símbolo $+$ é opcional na representação de números positivos.}.
+Para representar números negativos usamos o símbolo $-$ à esquerda do numeral\footnote{O uso do símbolo $+$ é opcional na representação de números positivos.}.
 \end{defn}
 
 \begin{obs}[$b\geq 10$]\label{obs:sistema_de_numeracao}
@@ -882,7 +882,7 @@ simplesmente descartando os dígitos $d_{j}$ com $j > k$.
 \begin{equation}
   \bar{x} = \pm d_0,d_1d_2\ldots d_{k}\times 10^{e}
 \end{equation}
-senão aproximamos $x$ por\footnote{Note que essas duas opções são equivalentes a somar $5$ no dígito a direita do corte e depois arredondar por corte, ou seja, arredondar por corte
+senão aproximamos $x$ por\footnote{Note que essas duas opções são equivalentes a somar $5$ no dígito à direita do corte e depois arredondar por corte, ou seja, arredondar por corte
 \begin{equation}  \pm(d_0,d_1d_2\ldots d_kd_{k+1}+ 5 \times10^{-(k+1)} )\times 10^{e}  \end{equation}}
 \begin{equation}
  \bar{x} = \pm (d_0,d_1d_2\ldots d_{k} + 10^{-k}) \times 10^{e}
@@ -1350,7 +1350,7 @@ O \verb+GNU Octave+ trabalha com representação complemento de 2 de números in
 ans =
    1   1   0   0   0   0   0   0
 \end{verbatim}
-mostra o barramento com $8$ \emph{bits} do número inteiro $3$. Note que a ordem dos \emph{bits} é inversa daquela apresentada no texto acima. Aqui, o \emph{bit} mais a esquerda fornece o coeficiente de $2^0$, enquanto o \emph{bit} mais a direita fornece o coeficiente de $-2^7$.
+mostra o barramento com $8$ \emph{bits} do número inteiro $3$. Note que a ordem dos \emph{bits} é inversa daquela apresentada no texto acima. Aqui, o \emph{bit} mais à esquerda fornece o coeficiente de $2^0$, enquanto o \emph{bit} mais à direita fornece o coeficiente de $-2^7$.
 
 O comando \verb+bitpack+ converte um barramento para o número em decimal, por exemplo:
 \begin{verbatim}
@@ -1950,7 +1950,7 @@ Uma maneira de interpretar essa regra é: calcula-se o erro relativo na forma no
   \begin{equation}
     \frac{|x-\bar{x}_2|}{|x|} = \frac{|0,666888-0,667|}{0,666888} \approx 0,000167...< 5\times 10^{-\RED{4}}.
   \end{equation}
-  Note que $\bar{x}_1$ possui $3$ dígitos significativos corretos e $\bar{x}_2$ possui $4$ dígitos significativos (o quarto dígito é o dígito $0$ que não aparece a direita, i.e, $\bar{x}_2=0.\RED{6670}$. Isto também leva a conclusão que $x_2$ aproxima melhor o valor de $x$ do que $x_1$ pois está mais próximo de $x$.
+  Note que $\bar{x}_1$ possui $3$ dígitos significativos corretos e $\bar{x}_2$ possui $4$ dígitos significativos (o quarto dígito é o dígito $0$ que não aparece à direita, i.e, $\bar{x}_2=0.\RED{6670}$. Isto também leva a conclusão que $x_2$ aproxima melhor o valor de $x$ do que $x_1$ pois está mais próximo de $x$.
 
 \item[c)] $\overline{x} = 9,999$ aproxima $x = 10$ com $4$ dígitos significativos corretos, pois
   \begin{equation}

--- a/cap_equacao1d/cap_equacao1d.tex
+++ b/cap_equacao1d/cap_equacao1d.tex
@@ -795,7 +795,7 @@ O teorema do ponto fixo nos fornece condições suficientes para a existência e
 
 \begin{obs}Seja $g:[a, b]\to [a, b]$, y=g(x).
   \begin{itemize}
-  \item Se $g(x)$ é uma contração, então $g(x)$ função contínua.
+  \item Se $g(x)$ é uma contração, então $g(x)$ é uma função contínua.
   \item Se $|g'(x)| < k$, $0 < k < 1$, para todo $x\in [a, b]$, então $g(x)$ é uma contração.
   \end{itemize}
 \end{obs}


### PR DESCRIPTION
Havia alguns erros de crase nas expressões "à direita" e "à esquerda". 

Além disso, a Observação 2.1.4 estava com a ordem errada. Para converter da base b_1 para base b_2, deve-se converter primeiro da base b_1 para a base decimal, para depois converter da base decimal para a base b_2.